### PR TITLE
Bump font-weight to ensure text readability

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -10,7 +10,7 @@ body {
 body {
   background: #4d4e53 url(../img/texture-noise.png);
   color: rgba(255,255,255,.95);
-  font-weight: 200;
+  font-weight: 300;
   text-align: center;
   text-shadow: 0 .05rem .1rem rgba(0,0,0,.5);
 }


### PR DESCRIPTION
On Linux, if Roboto font is installed, the `font-weight: 200` rule makes text really difficult to read.

![Unreadable text screenshot](http://www.1mage.fr/images/capturedcraumu.png)

Bumping it to a value like `300` makes it way more readable.

![Now readable text](https://cloud.githubusercontent.com/assets/411336/20041257/af5e04e6-a466-11e6-9c05-bbce7cc5a68e.png)
